### PR TITLE
Fixing URI for custom script location

### DIFF
--- a/101-vm-ext-win-cs-scriptfile/azuredeploy.parameters.json
+++ b/101-vm-ext-win-cs-scriptfile/azuredeploy.parameters.json
@@ -6,7 +6,7 @@
         "value": "myVM001"
     },
     "scriptFile": {
-        "value": "https://vmbootio.blob.core.windows.net/azurestack/VMCustomScriptExtension.ps1"
+        "value": "https://raw.githubusercontent.com/Azure/AzureStack-QuickStart-Templates/master/101-vm-ext-win-cs-scriptfile/VMCustomScriptExtension.ps1"
     },  
     "scriptName": {
         "value": "VMCustomScriptExtension.ps1"


### PR DESCRIPTION
Updating the azuredeploy.parameters.json file to point the custom script to the public Azure Stack QuickStart GitHub repository instead of using a custom storage account in an azure subscription.