### PR TITLE
Use subscription ID as the default password

### DIFF
--- a/101-simple-windows-vm/azuredeploy.json
+++ b/101-simple-windows-vm/azuredeploy.json
@@ -23,8 +23,9 @@
         "adminPassword": {
             "type": "securestring",
             "metadata": {
-                "description": "Password for the Virtual Machine."
-            }
+                "description": "The password for the Administrator account of the new VMs. Default value is subscription id"
+            },
+            "defaultValue": "[substring(resourcegroup().id,15,36)]"
         },
         "dnsNameForPublicIP": {
             "type": "string",

--- a/101-simple-windows-vm/azuredeploy.parameters.json
+++ b/101-simple-windows-vm/azuredeploy.parameters.json
@@ -11,9 +11,6 @@
     "adminUsername": {
       "value": "admin123"
     },
-    "adminPassword": {
-      "value": "GEN-PASSWORD"
-    },
     "dnsNameForPublicIP": {
       "value": "mydns001"
     },


### PR DESCRIPTION
Use the subscription ID as the default password in order to pass Windows password complexity checks.