### PR TITLE
Parameters files fixes for SharePoint load test templates

### DIFF
--- a/sharepoint-2013-non-ha-loadtest/azuredeploy.parameters.json
+++ b/sharepoint-2013-non-ha-loadtest/azuredeploy.parameters.json
@@ -2,35 +2,5 @@
     "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "TestControllerVMName": {
-            "value": "sprg-tc-0"
-        },
-        "TestControllerServiceUserName": {
-            "value": "tcserv"
-        },
-        "TargetSharePointServerVMName": {
-            "value": "sprg-sp-0"
-        },
-        "TargetSQLServerVMName": {
-            "value": "sprg-sql-0"
-        },
-        "TargetSharePointServerAdminUserName": {
-            "value": "Administrator"
-        },
-        "TargetSharePointServerUserPassword": {
-            "value": "GEN-PASSWORD"
-        },
-        "TargetSharePointSiteURL": {
-            "value": "http://sprg-sp-0.contoso.com"
-        },
-        "NumberOfLoadTestUsers": {
-            "value": 15
-        },
-        "LoadTestToRun": {
-            "value": "MySiteHostRW.loadtest"
-        },
-        "VisualStudioVersionNumber": { 
-            "value": 12
-        }
     }
 }

--- a/sharepoint-2013-sample-loadtest/azuredeploy.parameters.json
+++ b/sharepoint-2013-sample-loadtest/azuredeploy.parameters.json
@@ -2,23 +2,5 @@
     "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "TestControllerVMName": {
-            "value": "sprg-tc-0"
-        },
-        "TestControllerServiceUserName": {
-            "value": "tcserv"
-        },
-        "TargetSPServerVMName": {
-            "value": "sprg-sp-0"
-        },
-        "TargetSPSiteURL": {
-            "value": "http://sprg-sp-0.contoso.com"
-        },
-        "TargetSPTestUserName": {
-            "value": "spadmin@contoso.com"
-        },
-        "TargetSPTestUserPassword": {
-            "value": "GEN-PASSWORD"
-        }
     }
 }


### PR DESCRIPTION
Removing unnecessary parameters from the parameters files as the templates already have valid default values