### PR TITLE
Remove the newline in the description property value

### DIFF
--- a/sql-2014-non-ha/metadata.json
+++ b/sql-2014-non-ha/metadata.json
@@ -1,7 +1,6 @@
 {
   "itemDisplayName": "Deploys a SQL Server 2014 Always On Availability Group using DSC",
-  "description": "This template creates five new Azure VMs, with a public IP address, NAT'd RDP port, external and internal load balancer and VNet, it configures two VMs to be AD DCs for a new Forest and Domain, and creates a Windows
-	Cluster with the other three VMs, two VMs in the cluster are running SQL Server 2014 and are configured with an availability group and an availability group listener, the other VM is a File Share Witness for the cluster  ",
+  "description": "This template creates five new Azure VMs, with a public IP address, NAT'd RDP port, external and internal load balancer and VNet, it configures two VMs to be AD DCs for a new Forest and Domain, and creates a Windows Cluster with the other three VMs, two VMs in the cluster are running SQL Server 2014 and are configured with an availability group and an availability group listener, the other VM is a File Share Witness for the cluster.",
   "summary": "This template creates 5 Azure VMs with Active Directory and SQL Server Always On",
   "githubUsername": "simongdavies",
   "dateUpdated": "2015-06-03"


### PR DESCRIPTION
The newline is not valid in a JSON string and makes it so that a JSON parser fails to parse this file.