### PR TITLE
Updated iostorm template to support VaaS. 

### DIFF
--- a/iostorm-vm-iops-latency/azuredeploy.json
+++ b/iostorm-vm-iops-latency/azuredeploy.json
@@ -20,6 +20,23 @@
         "description": "The Windows version for the VM."
       }
     },
+	"vmSize": {
+      "type": "string",
+      "defaultValue": "Standard_A2",
+      "allowedValues": [
+        "Standard_A0",
+        "Standard_A1",
+        "Standard_A2",
+        "Standard_A3",
+        "Standard_A4",
+        "Standard_A5",
+        "Standard_A6",
+        "Standard_A7"
+      ],
+      "metadata": {
+        "description": "VM size supported by Azure Stack."
+      }
+	},
     "vmDataDiskSizeInGB": {
       "type": "int",
       "defaultValue": 5,
@@ -71,7 +88,6 @@
     "vmName": "[concat('vm', resourceGroup().name)]",
     "vmOsDiskName": "[concat('od', resourceGroup().name)]",
     "vmDataDiskName": "[concat('dd', resourceGroup().name)]",
-    "vmSize": "Standard_A2",
     "vmNicName": "[tolower(concat('nc', resourceGroup().name))]",
     "virtualNetworkName": "[tolower(concat('vn', resourceGroup().name))]",
     "vnetID": "[resourceId('Microsoft.Network/virtualNetworks',variables('virtualNetworkName'))]",
@@ -203,7 +219,7 @@
       ],
       "properties": {
         "hardwareProfile": {
-          "vmSize": "[variables('vmSize')]"
+          "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
           "computerName": "[variables('vmName')]",
@@ -257,7 +273,7 @@
       ],
       "properties": {
         "hardwareProfile": {
-          "vmSize": "[variables('vmSize')]"
+          "vmSize": "[parameters('vmSize')]"
         },
         "osProfile": {
           "computerName": "[variables('vmName')]",

--- a/iostorm-vm-iops-latency/azuredeploy.parameters.json
+++ b/iostorm-vm-iops-latency/azuredeploy.parameters.json
@@ -3,7 +3,10 @@
   "contentVersion": "1.16.07.29",
   "parameters": {
     "vmCount": {
-      "value": 5
+      "value": 1
+    },
+    "vmSize": {
+      "value": "Standard_A1"
     }
   }
 }

--- a/iostorm-vm-iops-latency/azuredeploy.parameters.json
+++ b/iostorm-vm-iops-latency/azuredeploy.parameters.json
@@ -6,7 +6,7 @@
       "value": 1
     },
     "vmSize": {
-      "value": "Standard_A1"
+      "value": "Standard_A0"
     }
   }
 }


### PR DESCRIPTION
Default VM size is now parameterized. Parameter file default VM size is Standard_A1 and VM count is 1