### PR TITLE
Fix type for nested resource "Microsoft.Azure.Diagnostics.IaasDiagnostics"

### DIFF
--- a/101-simple-windows-vm-diag/azuredeploy.json
+++ b/101-simple-windows-vm-diag/azuredeploy.json
@@ -209,7 +209,7 @@
       "resources": [
         {
           "name": "Microsoft.Azure.Diagnostics.IaasDiagnostics",
-          "type": "Microsoft.Compute/VirtualMachines/extensions",
+          "type": "extensions",
           "location": "[resourceGroup().location]",
           "apiVersion": "2015-06-15",
           "dependsOn": [


### PR DESCRIPTION
Nested resource type can’t have segments more than it's parent resource type.
Fixed type for nested resource "Microsoft.Azure.Diagnostics.IaasDiagnostics"; changed from "Microsoft.Compute/VirtualMachines/extensions" to "extensions"