### PR TITLE
fixed clusterInstallParameters (POSTINSTALLSCRIPTURI Script param was…

### DIFF
--- a/docker-swarm-ubuntu/azuredeploy.json
+++ b/docker-swarm-ubuntu/azuredeploy.json
@@ -114,7 +114,7 @@
         },
         "windowsJumpboxSku": {
             "type": "string",
-            "defaultValue": "2012-R2-Datacenter",
+            "defaultValue": "2016-Datacenter",
             "metadata": {
                 "description": "This is the windows sku used by the windows jumpbox"
             }
@@ -240,7 +240,7 @@
         "agentStorageAccountName": "[concat(variables('storageAccountBaseName'),'agent', variables('nameSuffix'))]",
         "jumpboxNSGName": "[concat(variables('orchestratorName'), '-jumpbox-nsg-', variables('nameSuffix'))]",
         "jumpboxNSGID": "[resourceId('Microsoft.Network/networkSecurityGroups',variables('jumpboxNSGName'))]",
-        "clusterInstallParameters": "[concat(variables('masterCount'), ' ',variables('masterVMNamePrefix'), ' ',variables('masterFirstAddr'), ' ',variables('adminUsername'),' ',' ', ' ', variables('baseSubnet'))]",        
+        "clusterInstallParameters": "[concat(variables('masterCount'), ' ',variables('masterVMNamePrefix'), ' ',variables('masterFirstAddr'), ' ',variables('adminUsername'), ' ','disabled', ' ', variables('baseSubnet'))]",        
         "jumpboxAddr": 4,
         "jumpboxVMName": "[concat('jumpboxVM-', variables('nameSuffix'))]",
         "jumpboxVMSize": "Standard_A1",

--- a/docker-swarm-ubuntu/parts/configure-swarm-azurestack.sh
+++ b/docker-swarm-ubuntu/parts/configure-swarm-azurestack.sh
@@ -1,18 +1,12 @@
 #!/bin/bash
 
 ###########################################################
-# Configure Mesos One Box
-#
-# This installs the following components
-# - zookeepr
-# - mesos master
-# - marathon
-# - mesos agent
+# Configure Docker Swarm Master and Agent(s)
 ###########################################################
 
 set -x
 
-echo "starting mesos cluster configuration"
+echo "starting Docker Swarm cluster configuration"
 date
 ps ax
 
@@ -275,4 +269,4 @@ fi
 echo "processes at end of script"
 ps ax
 date
-echo "completed mesos cluster configuration"
+echo "completed Docker Swarm cluster configuration"


### PR DESCRIPTION
The template did not work correctly. The Swarm cluster was not created after deployment because of missing parameter value for the shell script.

I change the following and now the Swarm cluster is up and running after deployment:
- Fixed clusterInstallParameters in ARM template. Script Parameter POSTINSTALLSCRIPTURI (value disabled) was not present and therefor the shell script for Docker Swarm setup did not worked correctly

- Changed comments and echos in the shell script to reflect Docker Swarm instead of mesos

- Changed  Windows Jump Host VM to Server 2016 Image  because Azure Stack ist a modern platform... :-)