### PR TITLE
Remove vmExtensionScriptLocation value

### DIFF
--- a/appservice-fileserver-standalone/azuredeploy.parameters.json
+++ b/appservice-fileserver-standalone/azuredeploy.parameters.json
@@ -28,9 +28,6 @@
         },
         "fileShareUserPassword": {
             "value": null
-        },
-        "vmExtensionScriptLocation": {
-            "value": "https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/appservice-fileserver-standalone"
         }
     }
 }


### PR DESCRIPTION
The correct value is in the defaultValue for the parameters.  The value listed in this file is incorrect and causes the custom script to fail.  Refers to issue: https://github.com/Azure/AzureStack-QuickStart-Templates/issues/307