### PR TITLE
Add FaultDomain and UpdateDomain Parameters for SQL Availability Sets

### DIFF
--- a/sql-2016-ha/azuredeploy.json
+++ b/sql-2016-ha/azuredeploy.json
@@ -121,6 +121,20 @@
             },
             "defaultValue": "Standard_LRS"
         },
+        "platformFaultDomainCount": {
+            "type": "int",
+            "metadata": {
+                "description": "Fault Domain Count Integer"
+            },
+            "defaultValue": "1"
+        },
+        "platformUpdateDomainCount": {
+            "type": "int",
+            "metadata": {
+                "description": "Update Domain Count Integer"
+            },
+            "defaultValue": "1"
+        },
         "virtualNetworkAddressRange": {
             "type": "string",
             "metadata": {
@@ -788,6 +802,12 @@
                     },
                     "sqlwNicName": {
                         "value": "[variables('sqlwNicName')]"
+                    },
+                    "platformFaultDomainCount": {
+                        "value": "[parameters('platformFaultDomainCount')]"
+                    },
+                    "platformUpdateDomainCount": {
+                        "value": "[parameters('platformUpdateDomainCount')]"
                     }
                 }
             }

--- a/sql-2016-ha/provisioningVM2.json
+++ b/sql-2016-ha/provisioningVM2.json
@@ -59,6 +59,12 @@
         },
         "sqlwNicName": {
             "type": "string"
+        },
+        "platformFaultDomainCount": {
+            "type": "int"
+        },
+        "platformUpdateDomainCount": {
+            "type": "int"
         }
     },
     "variables": {
@@ -76,8 +82,8 @@
         "apiVersion": "2016-03-30",
         "location": "[parameters('location')]",
         "properties": {
-            "platformFaultDomainCount": "3",
-            "platformUpdateDomainCount": "5"
+            "platformFaultDomainCount": "[parameters('platformFaultDomainCount')]",
+            "platformUpdateDomainCount": "[parameters('platformUpdateDomainCount')]"
         }
     },
     {

--- a/sql-2016-ha/provisioningVM2.json
+++ b/sql-2016-ha/provisioningVM2.json
@@ -76,8 +76,8 @@
         "apiVersion": "2016-03-30",
         "location": "[parameters('location')]",
         "properties": {
-            "platformFaultDomainCount": "1",
-            "platformUpdateDomainCount": "1"
+            "platformFaultDomainCount": "3",
+            "platformUpdateDomainCount": "5"
         }
     },
     {


### PR DESCRIPTION
It does not make sense to provision this in 1 and 1, we have 3 servers so we need to spread them around.