### PR TITLE
Update Hadoop to support Replication

### DIFF
--- a/hadoop-cluster/config/hdfs-site.xml
+++ b/hadoop-cluster/config/hdfs-site.xml
@@ -72,7 +72,7 @@
             default is used if replication is not specified in create time.
         </description>
         <name>dfs.replication</name>
-        <value>1</value>
+        <value>REPLICATION</value>
         <final>true</final>
     </property>
     <property>
@@ -80,7 +80,7 @@
             Minimal block replication.
         </description>
         <name>dfs.replication.min</name>
-        <value>1</value>
+        <value>REPLICATION</value>
         <final>true</final>
     </property>
     <property>
@@ -88,7 +88,7 @@
             Maximal block replication.
         </description>
         <name>dfs.replication.max</name>
-        <value>1</value>
+        <value>REPLICATION</value>
         <final>true</final>
     </property>
     <property>

--- a/hadoop-cluster/config/mapred-site.xml
+++ b/hadoop-cluster/config/mapred-site.xml
@@ -128,7 +128,7 @@
             The replication level for submitted job files. This should be around the square root of the number of nodes.
         </description>
         <name>mapreduce.client.submit.file.replication</name>
-        <value>1</value>
+        <value>REPLICATION</value>
         <final>true</final>
     </property>
 </configuration>

--- a/hadoop-cluster/hadoop_cluster.json
+++ b/hadoop-cluster/hadoop_cluster.json
@@ -117,6 +117,13 @@
             "metadata": {
                 "description": "Base URI for scripts and files."
             }
+        },
+        "replication" : {
+            "type":"int",
+            "defaultValue": 1,
+            "metadata": {
+                "description": "The number of copies of the underlying data in Hadoop.  Please note that increasing this will require at least double the storage."
+            }
         }
     },
     "variables": {
@@ -377,6 +384,9 @@
                     },
                     "batchSize": {
                         "value": "[parameters('batchSize')]"
+                    },
+                    "replication": {
+                        "value": "[parameters('replication')]"
                     }
                 }
             }
@@ -425,6 +435,9 @@
                     },
                     "numberWorkerNodes": {
                         "value": "[parameters('numberWorkerNodes')]"
+                    },
+                    "replication": {
+                        "value": "[parameters('replication')]"
                     },
                     "_artifactsLocation": {
                         "value": "[parameters('_artifactsLocation')]"

--- a/hadoop-cluster/hadoop_cluster.json
+++ b/hadoop-cluster/hadoop_cluster.json
@@ -490,6 +490,9 @@
                     "loadBalancerName": {
                         "value": "[variables('loadBalancerName')]"
                     },
+                    "replication": {
+                        "value": "[parameters('replication')]"
+                    },
                     "_artifactsLocation": {
                         "value": "[parameters('_artifactsLocation')]"
                     }

--- a/hadoop-cluster/jumpbox_node.json
+++ b/hadoop-cluster/jumpbox_node.json
@@ -33,6 +33,9 @@
         "loadBalancerName": {
             "type": "string"
         },
+        "replication": {
+            "type": "int"
+        },
         "_artifactsLocation": {
             "type": "string"
         }
@@ -164,7 +167,7 @@
                         "[concat(parameters('_artifactsLocation'),'/config/mapred-site.xml')]",
                         "[concat(parameters('_artifactsLocation'),'/config/yarn-site.xml')]"
                     ],
-                    "commandToExecute": "[concat('bash jumpboxSetup.sh',' ',parameters('numberWorkerNodes'),' ',parameters('adminPassword'))]"
+                    "commandToExecute": "[concat('bash jumpboxSetup.sh',' ',parameters('numberWorkerNodes'),' ',parameters('replication'),' ',parameters('adminPassword'))]"
                 }
             }
         }

--- a/hadoop-cluster/jumpbox_node.json
+++ b/hadoop-cluster/jumpbox_node.json
@@ -167,7 +167,7 @@
                         "[concat(parameters('_artifactsLocation'),'/config/mapred-site.xml')]",
                         "[concat(parameters('_artifactsLocation'),'/config/yarn-site.xml')]"
                     ],
-                    "commandToExecute": "[concat('bash jumpboxSetup.sh',' ',parameters('numberWorkerNodes'),' ',parameters('replication'),' ',parameters('adminPassword'))]"
+                    "commandToExecute": "[concat('bash jumpboxSetup.sh',' ',parameters('numberWorkerNodes'),' ',parameters('adminPassword'),' ',parameters('replication'))]"
                 }
             }
         }

--- a/hadoop-cluster/master_node.json
+++ b/hadoop-cluster/master_node.json
@@ -33,6 +33,9 @@
         "numberWorkerNodes": {
             "type": "int"
         },
+        "replication" : {
+            "type" : "int"
+        },
         "_artifactsLocation": {
             "type": "string"
         }
@@ -195,7 +198,7 @@
                         "[concat(parameters('_artifactsLocation'),'/config/mapred-site.xml')]",
                         "[concat(parameters('_artifactsLocation'),'/config/yarn-site.xml')]"
                     ],
-                    "commandToExecute": "[concat('bash ./hadoopSetup.sh ',parameters('numberWorkerNodes'))]"
+                    "commandToExecute": "[concat('bash ./hadoopSetup.sh ',parameters('numberWorkerNodes'),' ',parameters('replication'))]"
                 }
             }
         }

--- a/hadoop-cluster/parameters.json
+++ b/hadoop-cluster/parameters.json
@@ -25,6 +25,9 @@
         },
         "batchSize": {
             "value": 10
+        },
+        "replication": {
+            "value": 1
         }
     }
 }

--- a/hadoop-cluster/scripts/hadoopSetup.sh
+++ b/hadoop-cluster/scripts/hadoopSetup.sh
@@ -47,6 +47,7 @@ function check_error() {
 #
 #
 WORKERS=$1
+REPLICATION=$2
 
 ############################################################
 #
@@ -290,10 +291,13 @@ install_hadoop () {
     sed -i -e "s+MOUNT_LOCATION+$MOUNT+g" $HADOOP_HOME/etc/hadoop/core-site.xml
 
     sed -i -e "s+CLUSTER_NAME+$CLUSTER_NAME+g" $HADOOP_HOME/etc/hadoop/hdfs-site.xml
+    sed -i -e "s+REPLICATION+$REPLICATION+g" $HADOOP_HOME/etc/hadoop/hdfs-site.xml
 
     sed -i -e "s+CLUSTER_NAME+$CLUSTER_NAME+g" $HADOOP_HOME/etc/hadoop/yarn-site.xml
 
     sed -i -e "s+\${JAVA_HOME}+'$JAVA_HOME'+g" $HADOOP_HOME/etc/hadoop/hadoop-env.sh
+
+    sed -i -e "s+REPLICATION+$REPLICATION+g" $HADOOP_HOME/etc/hadoop/mapred-site.xml
 
     #
     # Global profile environment variables

--- a/hadoop-cluster/scripts/jumpboxSetup.sh
+++ b/hadoop-cluster/scripts/jumpboxSetup.sh
@@ -69,7 +69,7 @@ NUMBER_NODES="$1"
 # How many worker nodes
 ADMIN_PASSWORD="$2"
 
-ADMIN_PASSWORD="$3"
+REPLICATION="$3"
 
 # Check to see if ADMIN_USER has been passed in
 if [ $# -eq 5 ]; then

--- a/hadoop-cluster/scripts/jumpboxSetup.sh
+++ b/hadoop-cluster/scripts/jumpboxSetup.sh
@@ -69,9 +69,11 @@ NUMBER_NODES="$1"
 # How many worker nodes
 ADMIN_PASSWORD="$2"
 
+ADMIN_PASSWORD="$3"
+
 # Check to see if ADMIN_USER has been passed in
-if [ $# -eq 4 ]; then
-    ADMIN_USER="$3"
+if [ $# -eq 5 ]; then
+    ADMIN_USER="$4"
 fi
 
 ############################################################
@@ -233,11 +235,13 @@ install_hadoop () {
     sed -i -e "s+MOUNT_LOCATION+$MOUNT+g" $HADOOP_HOME/etc/hadoop/core-site.xml
 
     sed -i -e "s+CLUSTER_NAME+$CLUSTER_NAME+g" $HADOOP_HOME/etc/hadoop/hdfs-site.xml
+    sed -i -e "s+REPLICATION+$REPLICATION+g" $HADOOP_HOME/etc/hadoop/hdfs-site.xml
 
     sed -i -e "s+CLUSTER_NAME+$CLUSTER_NAME+g" $HADOOP_HOME/etc/hadoop/yarn-site.xml
 
     sed -i -e "s+\${JAVA_HOME}+'$JAVA_HOME'+g" $HADOOP_HOME/etc/hadoop/hadoop-env.sh
 
+sed -i -e "s+REPLICATION+$REPLICATION+g" $HADOOP_HOME/etc/hadoop/mapred-site.xml
     #
     # Global profile environment variables
     #

--- a/hadoop-cluster/worker_node.json
+++ b/hadoop-cluster/worker_node.json
@@ -40,6 +40,9 @@
             "type": "int",
             "minValue": 1,
             "maxValue": 40
+        },
+        "replication" : {
+            "type" : "int"
         }
     },
     "variables": {
@@ -185,7 +188,7 @@
                         "[concat(parameters('_artifactsLocation'),'/config/mapred-site.xml')]",
                         "[concat(parameters('_artifactsLocation'),'/config/yarn-site.xml')]"
                     ],
-                    "commandToExecute": "[concat('bash ./hadoopSetup.sh ',parameters('numberWorkerNodes'))]"
+                    "commandToExecute": "[concat('bash ./hadoopSetup.sh ',parameters('numberWorkerNodes'),' ',parameters('replication'))]"
                 }
             }
         }


### PR DESCRIPTION
Some users might need to use replication to ensure no data loss.  Also, in theory MR should run faster as you can schedule jobs over multiple nodes since data is replicated across multiple nodes.