### PR TITLE
fix breaking change from apiProfile update

### DIFF
--- a/ad-non-ha/adVmTemplate.json
+++ b/ad-non-ha/adVmTemplate.json
@@ -113,9 +113,11 @@
       "name": "[parameters('storageAccount')]",
       "type": "Microsoft.Storage/storageAccounts",
       "location": "[resourceGroup().location]",
-      "properties": {
-        "accountType": "[parameters('storageAccountType')]"
-      }
+      "sku": {
+          "name": "[parameters('StorageAccountType')]"
+      },
+      "kind": "Storage", 
+      "properties": {}
     },
     {
       "name": "[parameters('adDNicName')]",


### PR DESCRIPTION
The change in the apiProfile from here: https://github.com/Azure/AzureStack-QuickStart-Templates/commit/c3acf157833144da673aa0b8e8b2c66fcd6cd537#diff-50688c3b443076106fd26e0c41434778R4 is not compatible with the resource definition.  This change makes it compatible.