### PR TITLE
Sql 2016 alwayson changes

### DIFF
--- a/sql-2016-alwayson/Readme.md
+++ b/sql-2016-alwayson/Readme.md
@@ -10,7 +10,7 @@ This template deploys two SQL Server Enterprise, Standard or Developer instances
 * One VM (WS2016) configured as Domain Controller for a new forest with a single domain
 * Two VM (WS2016) configured as SQL Server 2016 SP1 or SP2 Enterprise/Standard/Developer (must use the marketplace images)
 * One VM (WS2016) configured as File Share Witness for the cluster
-* One Availability Set containing the SQL and FSW 2016 VMs
+* Two Availability Sets, one containing the SQL and FSW 2016 VMs, the other containing the Domain Controller VM.
 
 ## Notes
 

--- a/sql-2016-alwayson/Readme.md
+++ b/sql-2016-alwayson/Readme.md
@@ -5,10 +5,10 @@ This template deploys two SQL Server Enterprise, Standard or Developer instances
 * A network security group
 * A virtual network
 * Four storage accounts (One for AD, One for SQL, One for File Share witness and One for VM diagnostic)
-* Four public IP address (One for AD, Two for each SQL VM and One for Public LB bound to SQL Always On Listener)
+* Four public IP address (One for AD, One for each SQL VM and One for Public LB bound to SQL Always On Listener)
 * One external load balancer for SQL VMs with Public IP bound to the SQL Always On listener
 * One VM (WS2016) configured as Domain Controller for a new forest with a single domain
-* Two VM (WS2016) configured as SQL Server 2016 SP1 or SP2 Enterprise/Standard/Developer and clustered (must use the marketplace images)
+* Two VM (WS2016) configured as SQL Server 2016 SP1 or SP2 Enterprise/Standard/Developer (must use the marketplace images)
 * One VM (WS2016) configured as File Share Witness for the cluster
 * One Availability Set containing the SQL and FSW 2016 VMs
 

--- a/sql-2016-alwayson/azuredeploy.parameters.json
+++ b/sql-2016-alwayson/azuredeploy.parameters.json
@@ -3,13 +3,13 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "domainName": {
-            "value": "contoso.local"
+            "value": "fabrikam.local"
         },
         "sqlServerServiceAccountUserName": {
             "value": "sqlservice"
         },
         "adminUsername": {
-            "value": "locladmin"
+            "value": "localadmin"
         }
     }
 }


### PR DESCRIPTION
👋 Hello,

I have made a few changes to the sql-2016-alwayson *Readme.md* and *azuredeploy.parameters.json*.

# Changes
* Changed "Two for each SQL VM" to "One ..." as only one for each is deployed. Adding up to four total.
* Changed "One availability set" to "Two". [Two](https://github.com/Azure/AzureStack-QuickStart-Templates/blob/master/sql-2016-alwayson/azuredeploy.json#L319) are deployed in the ARM template. 
* Removed clustered as an option. The allowed values for the parameter **sqlServerSku** in *azuredeploy.json* only allow **Enterprise, Standard and SQLDEV**.
* Fixed a typo for the **adminUsername** parameter in *azuredeploy.parameters.json*.
* Changed the value for the parameter **domainName** in *azuredeploy.parameters.json* to be in line with the default value in *azuredeploy.json*